### PR TITLE
Fix free type variables

### DIFF
--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -840,7 +840,7 @@ function xpath_translate(a::AbstractString,b::AbstractString,c::AbstractString)
     String(take!(tr))
 end
 
-function xpath_expr{T<:AbstractString,H}(pd, xp::XPath{T}, filter::Tuple{Symbol,H}, position::Int, last::Int, output_hint::DataType)
+function xpath_expr{T<:AbstractString}(pd, xp::XPath{T}, filter::Tuple{Symbol,Any}, position::Int, last::Int, output_hint::DataType)
     op = filter[1]::Symbol
     args = filter[2]
     if op == :attribute

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -840,7 +840,7 @@ function xpath_translate(a::AbstractString,b::AbstractString,c::AbstractString)
     String(take!(tr))
 end
 
-function xpath_expr{T<:AbstractString}(pd, xp::XPath{T}, filter::Tuple{Symbol,ANY}, position::Int, last::Int, output_hint::DataType)
+function xpath_expr{T<:AbstractString,H}(pd, xp::XPath{T}, filter::Tuple{Symbol,H}, position::Int, last::Int, output_hint::DataType)
     op = filter[1]::Symbol
     args = filter[2]
     if op == :attribute


### PR DESCRIPTION
Fix https://github.com/JuliaIO/LibExpat.jl/issues/79 which prevents WinRPM usage.

Won't be adding tests as I don't have interest in doing so, but this was a quick enough fix so thought I'd open a PR.