### PR TITLE
use Compat.Unicode to fix errors on v0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.33.0
+Compat 0.41.0

--- a/src/LibExpat.jl
+++ b/src/LibExpat.jl
@@ -3,12 +3,13 @@ __precompile__()
 module LibExpat
 
 using Compat
+using Compat.Unicode
 
 import Base: getindex, show, parse
 
-if Compat.Sys.iswindows() 
+if Compat.Sys.iswindows()
     const libexpat = "libexpat-1"
-elseif Compat.Sys.isunix() 
+elseif Compat.Sys.isunix()
     const libexpat = "libexpat"
 end
 


### PR DESCRIPTION
`Base.isspace` is now `Unicode.isspace`, which is causing errors on nightly Julia builds (e.g. https://ci.appveyor.com/project/tkelman/zmq-jl-dvf4g/build/1.0.456/job/6320t6skvja0i8dg#L122 )