### PR TITLE
Fix use of old iterator protocol for strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
 julia:
   - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
   - julia_version: 0.7
-  - julia_version: latest
+  - julia_version: 1.0
+  - julia_version: nightly
 
 platform:
   - x86 # 32-bit

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -85,9 +85,9 @@ end
 const xpath_separators = Set(['+','(',')','[',']','<','>','!','=','|','/','*',','])
 
 function xpath_parse(xpath::T, ismacro=false) where T<:AbstractString
-    k = start(xpath)
+    k = firstindex(xpath)
     k, parsed, returntype, has_last_fn = xpath_parse_expr(xpath, k, 0, ismacro)
-    if !done(xpath,k)
+    if k ≤ ncodeunits(xpath) # assume that xpath_parse_expr uses proper character indexing
         error("failed to parse to the end of the xpath (stopped at $k)")
     end
     return parsed, returntype


### PR DESCRIPTION
The patch assumes that `xparth_parse_expr` correctly uses character indexing (the old version also used this assumption).