### PR TITLE
Replace `search(s, t)` with `something(findfirst(t, s), 0:-1)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibExpat"
 uuid = "522f3ed2-3f36-55e3-b6df-e94fee9b0c07"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Expat_jll = "2e619515-83b5-522b-bb60-26c02a35a201"

--- a/gen/generate.jl
+++ b/gen/generate.jl
@@ -22,7 +22,7 @@ wc = wrap_c.init(
     clang_extraargs,
     (th, h) ->
     begin
-        if search(h, "expat") == 0:-1
+        if something(findfirst("expat", h), 0:-1) == 0:-1
             return false
         else
 #            println("th : $th, h : $h")

--- a/src/xpath.jl
+++ b/src/xpath.jl
@@ -1025,7 +1025,7 @@ function xpath_expr(pd, xp::XPath{T}, filter::Tuple{Symbol,Any}, position::Int, 
     elseif op == :contains
         a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
         b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
-        return !(isempty(search(a, b)))::Bool
+        return !(isempty(something(findfirst(b, a), 0:-1)))::Bool
     elseif op == :startswith
         a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
         b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
@@ -1050,7 +1050,7 @@ function xpath_expr(pd, xp::XPath{T}, filter::Tuple{Symbol,Any}, position::Int, 
     elseif op == :substring_before
         a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
         b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
-        i = first(search(a,b))
+        i = first(something(findfirst(b, a), 0:-1))
         if i < 1
             return ""
         else
@@ -1059,7 +1059,7 @@ function xpath_expr(pd, xp::XPath{T}, filter::Tuple{Symbol,Any}, position::Int, 
     elseif op == :substring_after
         a = xpath_string(xpath_expr(pd, xp, args[1]::SymbolAny, position, last, Any))::AbstractString
         b = xpath_string(xpath_expr(pd, xp, args[2]::SymbolAny, position, last, Any))::AbstractString
-        i = last(search(a,b))
+        i = last(something(findfirst(b, a), 0:-1))
         if i < 1
             return ""
         else


### PR DESCRIPTION
The `search` function has been removed from Julia. (It was deprecated in Julia 0.7 and removed in Julia 1.0).

This pull request replaces all uses of `search(s::AbstractString, t::AbstractString)` with `something(findfirst(t, s), 0:-1)`.

cc: @musm @vtjnash 